### PR TITLE
Make blinking Placeholder's Nucleus and ForeColor customizable in bot…

### DIFF
--- a/CSharpMath.CoreTests/MockTests.cs
+++ b/CSharpMath.CoreTests/MockTests.cs
@@ -12,16 +12,17 @@ namespace CSharpMath.CoreTests {
       var font = new TestFont(10);
       var provider = TestGlyphBoundsProvider.Instance;
       var glyphRun = new AttributedGlyphRun<TestFont, TGlyph>(hello, hello, font);
+      Assert.All(glyphRun.GlyphInfos, glyphInfo => Assert.Null(glyphInfo.Foreground));
       var width = provider.GetTypographicWidth(font, glyphRun);
       Approximately.Equal(width, 25,  0.01);
     }
-
     [Fact]
     public void TestGlyphBoundsWithM() {
       string america = "America";
       var font = new TestFont(10);
       var provider = TestGlyphBoundsProvider.Instance;
       var glyphRun = new AttributedGlyphRun<TestFont, TGlyph>(america, america, font);
+      Assert.All(glyphRun.GlyphInfos, glyphInfo => Assert.Null(glyphInfo.Foreground));
       var width = provider.GetTypographicWidth(font, glyphRun);
       Approximately.Equal(width, 40, 0.01);
     }

--- a/CSharpMath.Editor/MathKeyboard.cs
+++ b/CSharpMath.Editor/MathKeyboard.cs
@@ -44,8 +44,9 @@ namespace CSharpMath.Editor {
         ResetPlaceholders(mathAtom.Superscript);
         ResetPlaceholders(mathAtom.Subscript);
         switch (mathAtom) {
-          case Atoms.Placeholder _:
-            mathAtom.Nucleus = "\u25A1";
+          case Atoms.Placeholder placeholder:
+            placeholder.Color = LaTeXSettings.PlaceholderRestingColor;
+            placeholder.Nucleus = LaTeXSettings.PlaceholderRestingNucleus;
             break;
           case IMathListContainer container:
             foreach (var list in container.InnerLists)
@@ -62,10 +63,10 @@ namespace CSharpMath.Editor {
         blinkTimer.Start();
         if (value != MathKeyboardCaretState.Hidden &&
            MathList.AtomAt(_insertionIndex) is Atoms.Placeholder placeholder) 
-          (placeholder.Nucleus, _caretState) =
+          (placeholder.Nucleus, placeholder.Color, _caretState) =
             value == MathKeyboardCaretState.TemporarilyHidden
-            ? ("\u25A1", MathKeyboardCaretState.TemporarilyHidden)
-            : ("\u25A0", MathKeyboardCaretState.ShownThroughPlaceholder);
+            ? (LaTeXSettings.PlaceholderRestingNucleus, LaTeXSettings.PlaceholderRestingColor, MathKeyboardCaretState.TemporarilyHidden)
+            : (LaTeXSettings.PlaceholderActiveNucleus, LaTeXSettings.PlaceholderActiveColor, MathKeyboardCaretState.ShownThroughPlaceholder);
         else _caretState = value;
         RecreateDisplayFromMathList();
         RedrawRequested?.Invoke(this, EventArgs.Empty);

--- a/CSharpMath/Atom/Atoms/Placeholder.cs
+++ b/CSharpMath/Atom/Atoms/Placeholder.cs
@@ -1,9 +1,11 @@
+using System.Drawing;
 namespace CSharpMath.Atom.Atoms {
   /// <summary>A placeholder for future input</summary>
   public sealed class Placeholder : MathAtom {
-    public Placeholder(string nucleus) : base(nucleus) { }
+    public Color? Color { get; set; }
+    public Placeholder(string nucleus, Color? color) : base(nucleus) => Color = color;
     public override bool ScriptsAllowed => true;
     public new Placeholder Clone(bool finalize) => (Placeholder)base.Clone(finalize);
-    protected override MathAtom CloneInside(bool finalize) => new Placeholder(Nucleus);
+    protected override MathAtom CloneInside(bool finalize) => new Placeholder(Nucleus, Color);
   }
 }

--- a/CSharpMath/Atom/LaTeXSettings.cs
+++ b/CSharpMath/Atom/LaTeXSettings.cs
@@ -320,7 +320,11 @@ namespace CSharpMath.Atom {
       };
     public static MathAtom Times => new BinaryOperator("×");
     public static MathAtom Divide => new BinaryOperator("÷");
-    public static MathAtom Placeholder => new Placeholder("\u25A1");
+    public static Color? PlaceholderRestingColor { get; set; }
+    public static Color? PlaceholderActiveColor { get; set; }
+    public static string PlaceholderActiveNucleus { get; set; } = "\u25A0";
+    public static string PlaceholderRestingNucleus { get; set; } = "\u25A1";
+    public static Placeholder Placeholder => new Placeholder(PlaceholderRestingNucleus, PlaceholderRestingColor);
     public static MathList PlaceholderList => new MathList { Placeholder };
 
     public static AliasBiDictionary<string, FontStyle> FontStyles { get; } =

--- a/CSharpMath/Display/AttributedGlyphRun.cs
+++ b/CSharpMath/Display/AttributedGlyphRun.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 
@@ -7,9 +8,9 @@ namespace CSharpMath.Display {
   /// over the whole string. We use KernedGlyph objects instead of Glyphs to
   /// allow us to set kern on a per-glyph basis.</summary>
   public class AttributedGlyphRun<TFont, TGlyph> where TFont : FrontEnd.IFont<TGlyph> {
-    public AttributedGlyphRun(string text, IEnumerable<TGlyph> glyphs, TFont font, bool isPlaceHolder = false) {
+    public AttributedGlyphRun(string text, IEnumerable<TGlyph> glyphs, TFont font, bool isPlaceHolder = false, Color? color = null) {
       Text = new StringBuilder(text);
-      GlyphInfos = glyphs.Select(g => new GlyphInfo<TGlyph>(g)).ToList();
+      GlyphInfos = glyphs.Select(g => new GlyphInfo<TGlyph>(g) { Foreground = color }).ToList();
       Font = font;
       Placeholder = isPlaceHolder;
     }

--- a/CSharpMath/Display/Typesetter.cs
+++ b/CSharpMath/Display/Typesetter.cs
@@ -337,7 +337,7 @@ namespace CSharpMath.Display {
               var nucleusText = atom.Nucleus;
               var glyphs = _context.GlyphFinder.FindGlyphs(_font, nucleusText);
               var current = new AttributedGlyphRun<TFont, TGlyph>(
-                nucleusText, glyphs, _font, atom is Placeholder);
+                nucleusText, glyphs, _font, atom is Placeholder, (atom as Placeholder)?.Color);
               _currentLine.AppendGlyphRun(current);
               if (_currentLineIndexRange.Location == Range.UndefinedInt)
                 _currentLineIndexRange = atom.IndexRange;


### PR DESCRIPTION
…h CaretStates (#167)

* Make blinking Placeholder's Nucleus and ForeColor customizable in both CaretStates

* Renaming of Placeholder-related variables + refactor (#167)

- Rename Placholder's "ForeColor" to "Color".
- Use property initializer GlyphInfo.Foreground.
- Restore "readonly field" instead of property getter for LaTeXSettings.Dummy.
- Use the name parts "Resting" and "Active" in the placeholder setting names (instead of "Hiding" and "FullShow" which are related to the caret but do not fit a blinking placeholder).
- Use variable name "placeholder" instead of "ph".

* Add unit tests for customizable placeholder (#167)

* Disable parallelization of customizable placeholder unit tests

Also: verify more in LaTeXSettings_Placeholder_IsNewInstance.

* Add unit test AllCustomizablePlaceholderPropertiesAreResetOnCaretVisible (#167)

Also: in the MockTests class, verify that AttributedGlyphRun sets the GlyphInfo.Foreground to null (default color).

* Unit test CustomizedPlaceholderBlinks: test complete cycle

* Fix failing unit test CaretTimerResetsOnKeyPress

* Use Assert.All instead of Assert.True(enumerable.All(pred))

* Revert "Fix failing unit test CaretTimerResetsOnKeyPress"

This reverts commit 9925952a078e0bc21cee91d1d372d3b0259d699f.

* Replace Assert.NotEqual + replace hardcoded strings by constants

* Refactoring and cleaning (of customizable placeholder tests and more)

* Placeholder tests: use Assert.NotSame and async Task